### PR TITLE
Update DisCatSharp packages and modify return values and properties

### DIFF
--- a/AGC Management.csproj
+++ b/AGC Management.csproj
@@ -22,15 +22,15 @@
         <PackageReference Include="Blazorise.Bootstrap5" Version="1.5.3" />
         <PackageReference Include="Blazorise.Components" Version="1.5.3" />
         <PackageReference Include="Blazorise.Snackbar" Version="1.5.3" />
-        <PackageReference Include="DisCatSharp" Version="10.6.2-nightly-012" />
+        <PackageReference Include="DisCatSharp" Version="10.6.5-nightly-003" />
         <PackageReference Include="DisCatSharp.Analyzer.Roselyn" Version="6.2.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="DisCatSharp.ApplicationCommands" Version="10.6.2-nightly-012" />
-        <PackageReference Include="DisCatSharp.CommandsNext" Version="10.6.2-nightly-012" />
-        <PackageReference Include="DisCatSharp.Common" Version="10.6.2-nightly-012" />
-        <PackageReference Include="DisCatSharp.Interactivity" Version="10.6.2-nightly-012" />
+        <PackageReference Include="DisCatSharp.ApplicationCommands" Version="10.6.5-nightly-003" />
+        <PackageReference Include="DisCatSharp.CommandsNext" Version="10.6.5-nightly-003" />
+        <PackageReference Include="DisCatSharp.Common" Version="10.6.5-nightly-003" />
+        <PackageReference Include="DisCatSharp.Interactivity" Version="10.6.5-nightly-003" />
         <PackageReference Include="Discord.OAuth2.AspNetCore" Version="3.0.0" />
         <PackageReference Include="ini-parser-new" Version="2.6.2" />
         <PackageReference Include="KawaiiAPI.NET" Version="1.1.0" />
@@ -42,7 +42,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.9.2" />
         <PackageReference Include="Npgsql" Version="8.0.3" />
         <PackageReference Include="RestSharp" Version="111.2.0" />
-        <PackageReference Include="Sentry" Version="4.7.0" />
+        <PackageReference Include="Sentry" Version="4.8.1" />
         <PackageReference Include="Serilog" Version="4.0.0" />
         <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/Commands/Utilities/StatsCommand.cs
+++ b/Commands/Utilities/StatsCommand.cs
@@ -71,7 +71,7 @@ public class StatsCommand : BaseCommandModule
         istring += $"CPU Cores: **{cpu}**\n";
 
         // Bot owner details
-        DiscordUser botowner = ctx.Client.CurrentApplication.Owners.First();
+        DiscordUser botowner = ctx.Client.CurrentApplication.Owner;
         istring += $"Bot Owner: **{botowner.UsernameWithDiscriminator}** ``{botowner.Id}``\n";
 
         embed.WithDescription(istring);

--- a/Utils/Helpers.cs
+++ b/Utils/Helpers.cs
@@ -420,7 +420,12 @@ public static class ToolSet
             return 0;
         }
 
-        return 7;
+        return DaysToSeconds(7);
+    }
+    
+    private static int DaysToSeconds(int days)
+    {
+        return days * 86400;
     }
 
     public static async Task SendWarnAsChannel(CommandContext ctx, DiscordUser user, DiscordEmbed uembed, string caseid)


### PR DESCRIPTION
This commit updates the version of DisCatSharp packages in the AGC Management project. It also changes the return value from a hardcoded integer to a method call converting days to seconds in Helpers.cs. Additionally, a change has been made to use a property instead of a method to get the bot owner information in the StatsCommand.cs class.